### PR TITLE
remove watch for content prop

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -326,7 +326,7 @@ export default {
   },
   data() {
     return {
-      isOnline: navigator.onLine || true,
+      isOnline: navigator.onLine || false,
       error: {
         occurred: false,
         message: "",
@@ -611,12 +611,6 @@ export default {
     }
   },
   watch: {
-    content(newValue) {
-      if (newValue) {
-        const newContent = this.addTitle(newValue, this.title);
-        this.editor.setContent(newContent, false);
-      }
-    },
     editable() {
       this.editor.setOptions({
         editable: this.editable


### PR DESCRIPTION
In order to release tiptap editor as an open source. we need to refactor the editor and tango flow so that cursor does not jump when props change.
currently it is working by hack in out app