### PR TITLE
[ios-bug] fix multiple enter key event at beginning of paragraph

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -259,8 +259,8 @@ export default {
               return true;
             },
             keydown: (view, event) => {
-              if (browser.ios && event.keyCode === 13)
-                view.lastSelection = view.state.selection;
+              if (event.keyCode === 13)
+                view.selectionAtEnterKeydown = view.state.selection;
               return false;
             }
           }


### PR DESCRIPTION
Due to following hack in prosemirror, our code has this bug.
```  
  // If this looks like the effect of pressing Enter (or was recorded
  // as being an iOS enter press), just dispatch an Enter key instead.
  if (((browser.ios && view.lastIOSEnter > Date.now() - 225 &&
        (!inlineChange || addedNodes.some(n => n.nodeName == "DIV" || n.nodeName == "P"))) ||
       (!inlineChange && $from.pos < parse.doc.content.size &&
        (nextSel = Selection.findFrom(parse.doc.resolve($from.pos + 1), 1, true)) &&
        nextSel.head == $to.pos)) &&
      view.someProp("handleKeyDown", f => f(view, keyEvent(13, "Enter")))) {
    view.lastIOSEnter = 0
    return
  }
```