### PR TITLE
remove close icon from embeds on clicking outside the element

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -184,6 +184,9 @@ export default {
           this.onUpdatePost({ blocks: data, title });
         },
         editorProps: {
+          handleClick: () => {
+            this.selectedEl = null;
+          },
           handlePaste: (view, event, slice) => {
             const singleNode =
               slice.openStart == 0 &&


### PR DESCRIPTION
Was trying to create a plugin to handle all close events for embeds, images etc. facing some issues in that, so added a temporary fix, will follow up with plugin solution. 